### PR TITLE
alias 'mic' to 'micro'

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -17,6 +17,8 @@ export PYTHON_HISTORY="$XDG_STATE_HOME"/python/python_history
 
 alias wget="wget --hsts-file=${XDG_DATA_HOME}/wget-hsts"
 
+alias mic=micro
+
 #
 #
 #


### PR DESCRIPTION
micro is slightly too much to type and I regularly mistype it. I tried out multiple alias such as `m`, `u`, `mu`, and `mic`. The alias `mic` seems to be the most ergonomic and least prone to typing errors.

my thoughts here assume qwerty keyboard layout.

I initially thought single letter aliases would be the fastest and least error prone. but I discovered that since I use my right thumb for hitting the space bar then any key also using my right hand did not flow well.

`mu` was even worst as not only does it entirely use my right hand but both the m and u require my pointer finger.

`mic` works well and I can think of a few reasons why.
* it has a nice rhythm bouncing between both of my hands (including the space after mic)
* I use separate fingers for `m` and `i`
* three letter commands are very natural already due to `git`/`vim`. in fact `mic` is almost a reverse of `vim`.

Closes #20 